### PR TITLE
Added API for blocking VIP feature to be used

### DIFF
--- a/VIPCore/VIPCore.sln
+++ b/VIPCore/VIPCore.sln
@@ -1,8 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VIPCore", "VIPCore\VIPCore.csproj", "{F346CAF2-E349-4FB7-AE79-5F1E50D39461}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34607.119
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VIPCore", "VIPCore\VIPCore.csproj", "{F346CAF2-E349-4FB7-AE79-5F1E50D39461}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VipCoreApi", "VipCoreApi\VipCoreApi.csproj", "{B26AF3C3-D82A-4584-AB4C-CF41FF2CF937}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VipCoreApi", "VipCoreApi\VipCoreApi.csproj", "{B26AF3C3-D82A-4584-AB4C-CF41FF2CF937}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +21,11 @@ Global
 		{B26AF3C3-D82A-4584-AB4C-CF41FF2CF937}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B26AF3C3-D82A-4584-AB4C-CF41FF2CF937}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B26AF3C3-D82A-4584-AB4C-CF41FF2CF937}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {88931F5D-3BDF-4BD5-AAB8-516BEF784BAC}
 	EndGlobalSection
 EndGlobal

--- a/VIPCore/VIPCore/VIPCore.cs
+++ b/VIPCore/VIPCore/VIPCore.cs
@@ -350,7 +350,7 @@ public class VipCore : BasePlugin
         if (target == null) return;
         if (target.AuthorizedSteamID == null) return;
 
-        OnClientAuthorizedAsync(target, target.AuthorizedSteamID);
+        Task.Run(async () => await OnClientAuthorizedAsync(target, target.AuthorizedSteamID));
     }
 
     [RequiresPermissions("@css/root")]
@@ -409,6 +409,14 @@ public class VipCore : BasePlugin
                         : $" [{value}]"),
                     (controller, _) =>
                     {
+                        var result = VipApi.PlayerUseFeature(player, key, featureState, featureType);
+
+                        if(result == HookResult.Handled || result == HookResult.Stop)
+                        {
+                            CreateMenu(player);
+                            return;
+                        }
+
                         var returnState = featureState;
                         if (featureType != FeatureType.Selectable)
                         {

--- a/VIPCore/VIPCore/VIPCore.cs
+++ b/VIPCore/VIPCore/VIPCore.cs
@@ -350,7 +350,9 @@ public class VipCore : BasePlugin
         if (target == null) return;
         if (target.AuthorizedSteamID == null) return;
 
-        Task.Run(async () => await OnClientAuthorizedAsync(target, target.AuthorizedSteamID));
+        var steamid = target.AuthorizedSteamID;
+
+        Task.Run(async () => await OnClientAuthorizedAsync(target, steamid));
     }
 
     [RequiresPermissions("@css/root")]

--- a/VIPCore/VIPCore/VipCoreApi.cs
+++ b/VIPCore/VIPCore/VipCoreApi.cs
@@ -19,6 +19,7 @@ public class VipCoreApi : IVipCoreApi
     public event Action<CCSPlayerController, string>? PlayerLoaded;
     public event Action<CCSPlayerController, string>? PlayerRemoved;
     public event Action? OnCoreReady;
+    public event Func<CCSPlayerController, string, FeatureState, FeatureType, HookResult?> OnPlayerUseFeature;
 
     public string GetTranslatedText(string name, params object[] args) => _vipCore.Localizer[name, args];
 
@@ -316,6 +317,11 @@ public class VipCoreApi : IVipCoreApi
     public void OnPlayerRemoved(CCSPlayerController player, string group)
     {
         PlayerRemoved?.Invoke(player, group);
+    }
+
+    public HookResult? PlayerUseFeature(CCSPlayerController player, string feature, FeatureState state, FeatureType type)
+    {
+        return OnPlayerUseFeature.Invoke(player, feature, state, type);
     }
 
     public T GetFeatureValue<T>(CCSPlayerController player, string feature)

--- a/VIPCore/VipCoreApi/IVipCoreApi.cs
+++ b/VIPCore/VipCoreApi/IVipCoreApi.cs
@@ -261,4 +261,9 @@ public interface IVipCoreApi
     /// Event checks if the core is loaded
     /// </summary>
     event Action? OnCoreReady;
+
+    /// <summary>
+    /// Event for prevent toggle use of VIP menu.
+    /// </summary>
+    event Func<CCSPlayerController, string, FeatureState, FeatureType, HookResult?> OnPlayerUseFeature;
 }


### PR DESCRIPTION
What do you think?

```cs
using CounterStrikeSharp.API;
using CounterStrikeSharp.API.Core;
using CounterStrikeSharp.API.Core.Capabilities;
using VipCoreApi;

namespace VipRestriction
{
    public class CPlugin : BasePlugin
    {
        public override string ModuleName => "Vip Restriction";
        public override string ModuleVersion => "1.0";
        private IVipCoreApi? _vipAPI { get; set; } 
        public static PluginCapability<IVipCoreApi> _vipCap { get; } = new("vipcore:core");

        public override void OnAllPluginsLoaded(bool hotReload)
        {
            _vipAPI = _vipCap.Get();

            if (_vipAPI == null)
                return;

            _vipAPI.OnPlayerUseFeature += OnPlayerUseFeature;
        }

        public HookResult? OnPlayerUseFeature(CCSPlayerController client, string feature, IVipCoreApi.FeatureState state, IVipCoreApi.FeatureType type)
        {
            if(client.TeamNum == 2)
            {
                Server.PrintToChatAll("Terrorist are not allowed.");
                return HookResult.Handled;
            }

            return HookResult.Continue;
        }
    }
}```