### PR TITLE
Feat: added screenmenu to core and api

### DIFF
--- a/VIPCore/VIPCore/Cfg.cs
+++ b/VIPCore/VIPCore/Cfg.cs
@@ -26,7 +26,7 @@ public class CoreConfig
 {
     public int TimeMode { get; init; } = 0;
     public int ServerId { get; init; } = 0;
-    public bool UseCenterHtmlMenu { get; init; } = true;
+    public string MenuType { get; set; } = "screen";
     [JsonPropertyName("ServerIP")] public string ServerIp { get; init; } = "0.0.0.0";
     public int ServerPort { get; init; } = 27015;
 

--- a/VIPCore/VIPCore/VIPCore.csproj
+++ b/VIPCore/VIPCore/VIPCore.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CounterStrikeSharp.API" Version="1.0.304" />
+    <PackageReference Include="CS2ScreenMenuAPI" Version="2.7.0" />
     <PackageReference Include="Dapper" Version="2.1.21" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />

--- a/VIPCore/VIPCore/VipCoreApi.cs
+++ b/VIPCore/VIPCore/VipCoreApi.cs
@@ -5,6 +5,7 @@ using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Cvars;
 using CounterStrikeSharp.API.Modules.Entities;
 using CounterStrikeSharp.API.Modules.Menu;
+using CS2ScreenMenuAPI.Internal;
 using Microsoft.Extensions.Logging;
 using VipCoreApi;
 using static VipCoreApi.IVipCoreApi;
@@ -365,7 +366,7 @@ public class VipCoreApi : IVipCoreApi
             File.WriteAllText(configFilePath,
                 JsonSerializer.Serialize(defaultConfig,
                     new JsonSerializerOptions
-                        { WriteIndented = true, ReadCommentHandling = JsonCommentHandling.Skip }));
+                    { WriteIndented = true, ReadCommentHandling = JsonCommentHandling.Skip }));
             return defaultConfig;
         }
 
@@ -383,11 +384,14 @@ public class VipCoreApi : IVipCoreApi
         return LoadConfig<T>(name, ModulesConfigDirectory);
     }
 
-    public IMenu CreateMenu(string title)
+    public IMenu CreateHtmlMenu(string title)
     {
-        return _vipCore.CoreConfig.UseCenterHtmlMenu ? new CenterHtmlMenu(title, _vipCore) : new ChatMenu(title);
+        return new CenterHtmlMenu(title, _vipCore);
     }
-
+    public ScreenMenu CreateScreenMenu(string title)
+    {
+        return new ScreenMenu(title, _vipCore);
+    }
     public void SetPlayerCookie<T>(ulong steamId64, string key, T value)
     {
         if (!_playersCookie.TryGetValue(steamId64, out var cookie))

--- a/VIPCore/VipCoreApi/IVipCoreApi.cs
+++ b/VIPCore/VipCoreApi/IVipCoreApi.cs
@@ -1,5 +1,6 @@
 ﻿using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Menu;
+using CS2ScreenMenuAPI.Internal;
 
 namespace VipCoreApi;
 
@@ -80,12 +81,12 @@ public interface IVipCoreApi
     /// <param name="feature"></param>
     /// <param name="newState"></param>
     void SetPlayerFeatureState(CCSPlayerController player, string feature, FeatureState newState);
-    
+
     /// <summary>
     /// Turns off all functions
     /// </summary>
     void DisableAllFeatures();
-    
+
     /// /// <summary>
     /// Turns on all the functions
     /// </summary>
@@ -228,14 +229,21 @@ public interface IVipCoreApi
     /// <returns></returns>
     T LoadConfig<T>(string name);
 
+
     /// <summary>
-    /// Returns a menu depending on the UseCenterHtmlMenu parameter from the config.
+    /// Returns an HTML menu.
     /// </summary>
     /// <param name="title"></param>
     /// <returns></returns>
-    IMenu CreateMenu(string title);
+    IMenu CreateHtmlMenu(string title);
 
-    
+    /// <summary>
+    /// Returns a screen menu.
+    /// </summary>
+    /// <param name="title"></param>
+    /// <returns></returns>
+    ScreenMenu CreateScreenMenu(string title);
+
     /// <summary>
     /// Returns server id
     /// </summary>

--- a/VIPCore/VipCoreApi/IVipFeature.cs
+++ b/VIPCore/VipCoreApi/IVipFeature.cs
@@ -1,5 +1,6 @@
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Menu;
+using CS2ScreenMenuAPI.Internal;
 using static VipCoreApi.IVipCoreApi;
 
 namespace VipCoreApi;
@@ -23,7 +24,7 @@ public abstract class VipFeatureBase : IVipFeature
     public string ModulesConfigDirectory => Api.ModulesConfigDirectory;
 
     public string GetDatabaseConnectionString => Api.GetDatabaseConnectionString;
-    
+
     protected VipFeatureBase(IVipCoreApi api)
     {
         Api = api;
@@ -44,7 +45,7 @@ public abstract class VipFeatureBase : IVipFeature
     public virtual void OnPlayerRemoved(CCSPlayerController player, string group)
     {
     }
-    
+
     public virtual void OnSelectItem(CCSPlayerController player, FeatureState state)
     {
     }
@@ -91,7 +92,8 @@ public abstract class VipFeatureBase : IVipFeature
 
     public T LoadConfig<T>(string name) => Api.LoadConfig<T>(name);
 
-    public IMenu CreateMenu(string title) => Api.CreateMenu(title);
+    public IMenu CreatHtmlMenu(string title) => Api.CreateHtmlMenu(title);
+    public ScreenMenu CreateScreenMenu(string title) => Api.CreateScreenMenu(title);
 
     public void PrintToChat(CCSPlayerController player, string message) => Api.PrintToChat(player, message);
 

--- a/VIPCore/VipCoreApi/VipCoreApi.csproj
+++ b/VIPCore/VipCoreApi/VipCoreApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CounterStrikeSharp.API" Version="1.0.304" />
+    <PackageReference Include="CS2ScreenMenuAPI" Version="2.7.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi.

I've changed some things if that's okay with you. Since 100% no one is using ChatMenu now i replaced the UseCenterHtmlMenu from config with MenuType for screen and html.

I've changed the API by adding CreateScreenMenu and CreateHtmlMenu.

I don't know if that will be okay with the modules that uses the create menu function (if it is any).